### PR TITLE
Add redirect assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ chai.request('http://localhost:8080')
 
 ### .req (cb)
 
-* **@param** _{Function}_ callback 
+* **@param** _{Function}_ callback
 * **@cb** {Request} object
 * **@cb** {Function} next (optional)
 * **@returns** {this} for chaining
@@ -84,7 +84,7 @@ chai.request(app)
 
 ### .res (cb)
 
-* **@param** _{Function}_ callback 
+* **@param** _{Function}_ callback
 * **@cb** {Response}
 
 Invoke the request to to the server. The response
@@ -163,6 +163,15 @@ expect(req).to.be.html;
 expect(req).to.be.text;
 ```
 
+
+### .redirect / .redirectTo(url)
+
+Assert that a `Response` redirects, optionally to a given url.
+
+```js
+expect(res).to.redirect;
+expect(res).to.redirectTo('http://example.com');
+```
 
 ## License
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -203,4 +203,50 @@ module.exports = function (chai, _) {
   Object
     .keys(contentTypes)
     .forEach(checkContentType);
+
+  /**
+   * ### .redirect
+   *
+   * Assert that a `Response` object has a redirect status code.
+   *
+   * ```js
+   * expect(res).to.redirect;
+   * ```
+   *
+   * @name redirect
+   * @api public
+   */
+
+  Assertion.addProperty('redirect', function() {
+    var redirectCodes = [301, 302, 303]
+      , statusCode = this._obj.statusCode;
+
+    this.assert(
+        redirectCodes.indexOf(statusCode) >= 0
+      , "expected redirect with 30{1-3} status code but got " + statusCode
+      , "expected not to redirect but got " + statusCode + " status"
+    );
+  });
+
+  /**
+   * ### .redirectTo
+   *
+   * Assert that a `Response` object has a redirects to the supplied location.
+   *
+   * ```js
+   * expect(res).to.redirectTo('http://example.com');
+   * ```
+   *
+   * @param {String} location url
+   * @name redirectTo
+   * @api public
+   */
+
+  Assertion.addMethod('redirectTo', function(destination) {
+    new Assertion(this._obj).to.redirect;
+
+    var assertion = new Assertion(this._obj);
+    _.transferFlags(this, assertion);
+    assertion.with.header('location', destination);
+  });
 };

--- a/test/http.js
+++ b/test/http.js
@@ -148,4 +148,48 @@ describe('assertions', function () {
       res.should.not.be.html;
     }).should.throw('expected \'text/html\' to not include \'text/html\'');
   });
+
+  it('#redirect', function () {
+    var res = { statusCode: 200 };
+    res.should.not.redirect;
+
+    [301, 302, 303].forEach(function (statusCode) {
+      var res = { statusCode: statusCode };
+      res.should.redirect;
+    });
+
+    res = { statusCode: 302 };
+    res.should.redirect;
+
+    res = { statusCode: 303 };
+    res.should.redirect;
+
+    (function () {
+      var res = { statusCode: 200 };
+      res.should.redirect;
+    }).should.throw('expected redirect with 30{1-3} status code but got 200');
+
+    (function () {
+      var res = { statusCode: 301 };
+      res.should.not.redirect;
+    }).should.throw('expected not to redirect but got 301 status');
+  });
+
+  it('#redirectTo', function () {
+    var res = { statusCode: 301, headers: { location: 'foo' } };
+    res.should.redirectTo('foo');
+
+    var res = { statusCode: 301, headers: { location: 'bar' } };
+    res.should.not.redirectTo('foo');
+
+    (function () {
+      var res = { statusCode: 301, headers: { location: 'foo' } };
+      res.should.not.redirectTo('foo');
+    }).should.throw('expected header \'location\' to not have value foo');
+
+    (function () {
+      var res = { statusCode: 301, headers: { location: 'bar' } };
+      res.should.redirectTo('foo');
+    }).should.throw('expected header \'location\' to have value foo');
+  });
 });


### PR DESCRIPTION
### .redirect / .redirectTo(url)

Assert that a `Response` redirects, optionally to a given url.

``` js
expect(res).to.redirect;
expect(res).to.redirectTo('http://example.com');
```
