### PR TITLE
Fix #10: Inspect res.redirects for redirect assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ expect(res).to.redirect;
 
 * **@param** _{String}_ location url
 
-Assert that a `Response` object has a redirects to the supplied location.
+Assert that a `Response` object redirects to the supplied location.
 
 ```js
 expect(res).to.redirectTo('http://example.com');

--- a/lib/http.js
+++ b/lib/http.js
@@ -222,10 +222,11 @@ module.exports = function (chai, _) {
 
   Assertion.addProperty('redirect', function() {
     var redirectCodes = [301, 302, 303]
-      , statusCode = this._obj.statusCode;
+      , statusCode = this._obj.statusCode
+      , redirects = this._obj.redirects;
 
     this.assert(
-        redirectCodes.indexOf(statusCode) >= 0
+        redirectCodes.indexOf(statusCode) >= 0 || redirects && redirects.length
       , "expected redirect with 30{1-3} status code but got " + statusCode
       , "expected not to redirect but got " + statusCode + " status"
     );
@@ -234,7 +235,7 @@ module.exports = function (chai, _) {
   /**
    * ### .redirectTo
    *
-   * Assert that a `Response` object has a redirects to the supplied location.
+   * Assert that a `Response` object redirects to the supplied location.
    *
    * ```js
    * expect(res).to.redirectTo('http://example.com');
@@ -246,11 +247,21 @@ module.exports = function (chai, _) {
    */
 
   Assertion.addMethod('redirectTo', function(destination) {
+    var redirects = this._obj.redirects;
+
     new Assertion(this._obj).to.redirect;
 
-    var assertion = new Assertion(this._obj);
-    _.transferFlags(this, assertion);
-    assertion.with.header('location', destination);
+    if(redirects && redirects.length) {
+      this.assert(
+        redirects.indexOf(destination) > -1
+        , 'expected redirect to ' + destination + ' but got ' + redirects.join(' then ')
+        , 'expected not to redirect to ' + destination + ' but got ' + redirects.join(' then ')
+      );
+    } else {
+      var assertion = new Assertion(this._obj);
+      _.transferFlags(this, assertion);
+      assertion.with.header('location', destination);
+    }
   });
 
   /**

--- a/test/http.js
+++ b/test/http.js
@@ -158,11 +158,15 @@ describe('assertions', function () {
       res.should.redirect;
     });
 
-    res = { statusCode: 302 };
-    res.should.redirect;
+    ({
+      statusCode: 200,
+      redirects: ['http://example.com']
+    }).should.redirect;
 
-    res = { statusCode: 303 };
-    res.should.redirect;
+    ({
+      statusCode: 200,
+      redirects: []
+    }).should.not.redirect;
 
     (function () {
       var res = { statusCode: 200 };
@@ -179,7 +183,13 @@ describe('assertions', function () {
     var res = { statusCode: 301, headers: { location: 'foo' } };
     res.should.redirectTo('foo');
 
-    var res = { statusCode: 301, headers: { location: 'bar' } };
+    res = { statusCode: 301, headers: { location: 'bar' } };
+    res.should.not.redirectTo('foo');
+
+    res = { statusCode: 200, redirects: ['bar'] };
+    res.should.redirectTo('bar');
+
+    res = { statusCode: 200, redirects: ['bar'] };
     res.should.not.redirectTo('foo');
 
     (function () {
@@ -191,6 +201,11 @@ describe('assertions', function () {
       var res = { statusCode: 301, headers: { location: 'bar' } };
       res.should.redirectTo('foo');
     }).should.throw('expected header \'location\' to have value foo');
+
+    (function () {
+      var res = { statusCode: 200, redirects: ['bar', 'baz'] };
+      res.should.redirectTo('foo');
+    }).should.throw('expected redirect to foo but got bar then baz');
   });
 
   it('#param', function () {


### PR DESCRIPTION
With these changes, `redirect` and `redirectTo` assertions should work as expected when superagent follows redirects by inspecting `res.redirects`.  They still work when the agent doesn't follow redirects (`.redirects(0)`) by inspecting a combination of the status code and location header.
