### PR TITLE
Bug #27, Add support for proxy servers via "superagent-proxy"

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -171,6 +171,7 @@ module.exports = function (app) {
 };
 
 module.exports.Test = Test;
+module.exports.Request = Test;
 module.exports.agent = TestAgent;
 module.exports.addPromises = function (Promise) {
   Test.Promise = Promise;


### PR DESCRIPTION
Hi @keithamus,

Thanks for your help - pull when you have a chance...

We expose the `superagent.Request` object in `chai-http/lib/request.js`.

To use:

```js
chai.use(require('chai-http'));

// This line now works!
require('superagent-proxy')(chai.request);

chai
  .request('http://external.example.com')
  .get('/')
  .proxy('http://my-proxy.example.org:80')
  .end(function (res) {

});
```

See, bug #27 for more discussion.

Yours,

Nick