### PR TITLE
Documentation: `throw`ing from promise chains doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,29 @@ chai.request(app)
   .then(function (res) {
      expect(res).to.have.status(200);
   })
-  .catch(function (err) {
-     throw err;
-  })
+  .then(done, done); // where `done` is the callback function from your testing library
 ```
+
+When using a testing library like Mocha that relies on a `done` callback for asynchronous
+tests, always make sure to finish the promise chain by invoking the `done` callback. For instance,
+
+```js
+describe('when testing asynchronous code', function () {
+  it('is essential to invoke the callback function', function (done) { // async callback passed in as parameter
+    chai.request(app).get('/')
+    .then(function (response) {
+      // ...
+    })
+    .then(done, done); // done will get called on both success and failure
+  });
+});
+```
+
+If the error path doesn't call the `done` function, then errors -- including assertion failures -- will
+happen completely silently. 
+
+Note that `throw`ing an error from within a promise chain, even inside a `.catch(...)` block, will not
+be propagated outside of the promise chain.
 
 Since Node.js version 0.10.x and lower does not have native promise support you can use [kriskowal/q](https://github.com/kriskowal/q) for them. Use the `addPromise` function to do this. For example:
 ```js

--- a/README.md
+++ b/README.md
@@ -133,21 +133,7 @@ chai.request(app)
 ```
 
 When using a testing library like Mocha that relies on a `done` callback for asynchronous
-tests, always make sure to finish the promise chain by invoking the `done` callback. For instance,
-
-```js
-describe('when testing asynchronous code', function () {
-  it('is essential to invoke the callback function', function (done) { // async callback passed in as parameter
-    chai.request(app).get('/')
-    .then(function (response) {
-      // ...
-    })
-    .then(done, done); // done will get called on both success and failure
-  });
-});
-```
-
-If the error path doesn't call the `done` function, then errors -- including assertion failures -- will
+tests, always make sure to finish the promise chain by invoking the `done` callback. If the error path doesn't call the `done` function, then errors -- including assertion failures -- will
 happen completely silently. 
 
 Note that `throw`ing an error from within a promise chain, even inside a `.catch(...)` block, will not


### PR DESCRIPTION
When using chai-http with Promises, the documentation advises that we do something like,

```js
.catch(function (err) {
  throw err;
})
```

This doesn't work. Any exception thrown from a promise chain gets passed through to the rejection callback. If a developer tries the above, they'll find that their code fails silently. Any exceptions, including assertion failures, simply disappear.

This makes sense when you think about it: the original code block has long since completely by the time our async code runs (and throws an exception).

The solution is to make sure that we always always always end a test promise chain by invoking the testing framework's async `done` callback. This is actually [how the plugin itself](https://github.com/chaijs/chai-http/blob/585a40bc8045f7ecf339b254a67e8bf707a3bd68/test/request.js#L72) handles it.

Please consider this a rough draft. Feedback welcome! :grin: 