### PR TITLE
Clarify the usage of query parameters in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@ chai.request(app)
 // Chain some GET query parameters
 chai.request(app)
   .get('/search')
-  .query('name', 'foo')
-  .query('limit', '10') // /search?name=foo&limit=10
+  .query({name: 'foo', limit: 10}) // /search?name=foo&limit=10
 ```
 
 #### Dealing with the response - traditional


### PR DESCRIPTION
The Query parameters should be passed as an object not as key/value parameter-pairs. Took me quite a while to figure this out, that's why I've updated the README