### PR TITLE
Superagent to Version 1.0.x + Update query parameter usage also in comment

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -89,8 +89,7 @@ var http = require('http')
  * // Chain some GET query parameters
  * chai.request(app)
  *   .get('/search')
- *   .query('name', 'foo')
- *   .query('limit', '10') // /search?name=foo&limit=10
+ *   .query({name: 'foo', limit: 10}) // /search?name=foo&limit=10
  * ```
  *
  * #### Dealing with the response - traditional

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
       "methods": "0.0.x"
-    , "superagent": "0.19.x"
+    , "superagent": "1.0.x"
     , "cookiejar": "2.0.x"
     , "qs": "2.0.x"
   },


### PR DESCRIPTION
I've updated Superagent to Version 1.0.x (https://github.com/chaijs/chai-http/issues/34) - it works on my project and also the tests passed

Additionally last time I was changing the README, I edited it directly but now I noticed that it's actually built from the comment, and I've applied the same changes about query parameters also in the comments so that the README is built properly