### PR TITLE
Add example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ In the above example, Mocha uses `describe()` to group together a set of tests (
 there's only one test) and `it()` is used to describe a single logical test.  The `done` function
 is passed into the function that creates the test, and Chai-Http is used to POST to the server.
 Once the results are returned, the `end` function is called, the results are tested and we
-call the `done()`.  Calling the `done` function signals to Mocha that the results of
+call `done()`.  Calling the `done` function signals to Mocha that the results of
 the HTTP call have returned and the test can be evaluated.
 
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ expect(res).to.not.have.cookie('PHPSESSID');
 ```
 
 ## Usage Examples
-#### Mocha
+### Mocha
 Chai-Http is commonly used in conjunction with the [Mocha test framework](http://mochajs.org/) 
 and the Chai Assertion Library.
 
@@ -339,7 +339,7 @@ callback has been called from within the test.
 Failure to pass in the `done` function and call it, will result in a test that always passes
 regardless of result returned from the HTTP call.
 
-##### Example
+#### Example
 ```js
 var chai = require('chai');
 var should = chai.should();

--- a/README.md
+++ b/README.md
@@ -324,6 +324,51 @@ expect(res).to.have.cookie('session_id', '1234');
 expect(res).to.not.have.cookie('PHPSESSID');
 ```
 
+## Usage Examples
+#### Mocha
+Chai-Http is commonly used in conjunction with the [Mocha test framework](http://mochajs.org/) 
+and the Chai Assertion Library.
+
+Mocha expects that the tests you write will return results synchronously.  Due to the nature
+of HTTP server calls, Chai-Http returns results *asynchronously*.  
+
+To facilitate asynchronous tests, Mocha allows you to pass a callback function, `done`, into
+each test.  Mocha will then refrain from evaluating the condition of the test until the 
+callback has been called from within the test.
+
+Failure to pass in the `done` function and call it, will result in a test that always passes
+regardless of result returned from the HTTP call.
+
+##### Example
+```js
+var chai = require('chai');
+var should = chai.should();
+var chaiHttp = require('chai-http');
+var server = require('../src/server');
+
+chai.use(chaiHttp);
+
+describe('POST', function () {
+    it('should respond successfully', function (done) {
+        chai.request(server)
+            .post('/api/equation')
+            .end(function (res) {
+                res.should.have.status(200);
+                done();
+            });
+
+    });
+});
+```
+
+In the above example, Mocha uses `describe()` to group together a set of tests (in this case,
+there's only one test) and `it()` is used to describe a single logical test.  The `done` function
+is passed into the function that creates the test, and Chai-Http is used to POST to the server.
+Once the results are returned, the `end` function is called, the results are tested and we
+call the `done()`.  Calling the `done` function signals to Mocha that the results of
+the HTTP call have returned and the test can be evaluated.
+
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -337,7 +337,10 @@ each test.  Mocha will then refrain from evaluating the condition of the test un
 callback has been called from within the test.
 
 Failure to pass in the `done` function and call it, will result in a test that always passes
-regardless of result returned from the HTTP call.
+regardless of the results of the HTTP call.  
+
+Further documentation may be found in the Mocha documentation under 
+[Asynchronous Code](http://mochajs.org/#asynchronous-code).
 
 #### Example
 ```js


### PR DESCRIPTION
I added an example of how Chai-Http works with Mocha.  A friend and I each struggled for a number of hours to figure out why our Chai-Http tests for a NodeJS API would always return true.  I did a lot of Google research and never found any full examples.  The only reason I figured out the done function was I happened to find someone's example in the Issues log when trying to figure out if there was a bug in the library.

I hope the example is useful.  If anyone has feedback, let me know!