### PR TITLE
Fixed two failing tests

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -296,7 +296,7 @@ module.exports = function (chai, _) {
     var assertion = new Assertion();
     _.transferFlags(this, assertion);
     assertion._obj = qs.parse(url.parse(this._obj.url).query);
-    assertion.property(name, value);
+    assertion.property.apply(assertion, arguments);
   });
 
   /**


### PR DESCRIPTION
There are two tests that [have been failing](https://travis-ci.org/chaijs/chai-http/jobs/105547469#L259-L271).  The `param` method wasn't working when called without a value. For example:  `expect(req).to.have.param('orderby')`