### PR TITLE
Issue 91: npm run posttest' fails when COVERALLS_REPO_TOKEN is unset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ deploy:
 env:
   global:
     - secure: DGaDDxh76Gv+qmu4SLuQDxmmZMpMiiVdIvveT1d3ly93zrqT7Pb9ur7P8Yz77AxU9UrMHEJ3Be05Uqe8xtTJCIora9io/tX4QLRtIXtRIOA3dYaYNBgXztQT7yzCi6E/L/DZa1+dNaGDpoUnLG0S3vpwhi3YjlWJDhLOfB3Txx0=
+    - FORCE_COVERALLS=1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Chai HTTP [![Build Status](https://travis-ci.org/chaijs/chai-http.svg?branch=master)](https://travis-ci.org/chaijs/chai-http)
+# Chai HTTP [![Build Status](https://travis-ci.org/chaijs/chai-http.svg?branch=master)](https://travis-ci.org/chaijs/chai-http) [![Coverage Status](https://coveralls.io/repos/github/chaijs/chai-http/badge.svg?branch=)](https://coveralls.io/github/chaijs/chai-http?branch=master)
 
 > HTTP integration testing with Chai assertions.
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "watch": "npm run build:js -- --watch",
     "server": "http-server -o -c-1",
     "test": "istanbul cover --report lcovonly _mocha",
-    "posttest": "if ! [ -z $COVERALLS_REPO_TOKEN ]; then cat coverage/lcov.info | coveralls; fi"
+    "posttest": "if [ -n \"$COVERALLS_REPO_TOKEN\" ] || [ \"${FORCE_COVERALLS}\" = \"1\" ]; then cat coverage/lcov.info | coveralls; fi"
   },
   "browser": {
     "http": false,

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "watch": "npm run build:js -- --watch",
     "server": "http-server -o -c-1",
     "test": "istanbul cover --report lcovonly _mocha",
-    "posttest": "if [ -z \"$COVERALLS_REPO_TOKEN\" ]; then cat coverage/lcov.info | coveralls; fi"
+    "posttest": "if ! [ -z $COVERALLS_REPO_TOKEN ]; then cat coverage/lcov.info | coveralls; fi"
   },
   "browser": {
     "http": false,


### PR DESCRIPTION
https://github.com/chaijs/chai-http/issues/91

Testing correctly if the COVERALLS_REPO_TOKEN env variable is not empty.
