### PR TITLE
add descriptive error if no app passed to request

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -248,6 +248,9 @@ function Test (app, method, path) {
 util.inherits(Test, Request);
 
 function serverAddress (app, path) {
+  if (!app) {
+    throw new Error("You must pass a valid application or server into the request");
+  }
   if ('string' === typeof app) {
     return app + path;
   }


### PR DESCRIPTION
While the code style might not be checking for param existence as a rule, I've seen this [query come up a lot](http://stackoverflow.com/questions/39544239/when-unit-testing-with-chai-what-does-typeerror-cannot-read-property-address) and figured a more descriptive error might be helpful.