### PR TITLE
Fix formatting for Chai website docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ chai.request(app)
      expect(res).to.have.status(200);
   });
 ```
+
 ##### Caveat
+
 Because the `end` function is passed a callback, assertions are run
 asynchronously. Therefore, a mechanism must be used to notify the testing
 framework that the callback has completed. Otherwise, the test will pass before


### PR DESCRIPTION
The formatting was affected by the lack of space above the heading, this seemed to be fine in Github flavoured markdown but whatever http://chaijs.com is using didn't like it.

![formatting issue](https://www.dropbox.com/s/04hda1lceenq0b8/Screenshot%202016-11-11%2011.50.33.png?dl=1)