### PR TITLE
Update request.js documentation

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -68,9 +68,10 @@ var http = require('http')
  * // Send some Form Data
  * chai.request(app)
  *   .post('/user/me')
- *   .field('_method', 'put')
- *   .field('password', '123')
- *   .field('confirmPassword', '123')
+ *   .type('form')
+ *   .send({'_method': 'put'})
+ *   .send({'password': '123'})
+ *   .send({'confirmPassword', '123'})
  * ```
  *
  * ```js


### PR DESCRIPTION
This clarifies how to send form data. `.field()` works for multi-part forms, but according to the [SuperAgent documentation](https://visionmedia.github.io/superagent/#post-/-put-requests) `.send()` should be used to send the post data as `application/x-www-form-urlencoded`. This addresses issue #86. There is an older pull request by @BenAychh, but it modified the README.md file directly. According to the discussion, the README.md file is generated based on request.js, and so the documentation should be modified here.