### PR TITLE
Fix some bad semicolon placements at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ it('fails, as expected', function(done) { // <= Pass in done callback
     expect(res).to.have.status(123);
     done();                               // <= Call done to signal callback end
   });
-}) ;
+});
 
 it('succeeds silently!', function() {   // <= No done callback
   chai.request('http://localhost:8080')
@@ -155,7 +155,7 @@ it('succeeds silently!', function() {   // <= No done callback
   .end(function(err, res) {
     expect(res).to.have.status(123);    // <= Test completes before this runs
   });
-}) ;
+});
 ```
 
 When `done` is passed in, Mocha will wait until the call to `done()`, or until
@@ -176,7 +176,7 @@ chai.request(app)
   })
   .catch(function (err) {
      throw err;
-  })
+  });
 ```
 
 __Note:__ Node.js version 0.10.x and some older web browsers do not have
@@ -195,7 +195,6 @@ if (!global.Promise) {
 }
 var chai = require('chai');
 chai.use(require('chai-http'));
-
 ```
 
 #### Retaining cookies with each request
@@ -216,8 +215,8 @@ agent
     return agent.get('/user/me')
       .then(function (res) {
          expect(res).to.have.status(200);
-      })
-  })
+      });
+  });
 ```
 
 ## Assertions


### PR DESCRIPTION
Hello everyone,

I realized that there was some bad placed/missing semicolons on README

There are more semicolons missing from previous examples (ex: Line 70) but I think that it make sense to not add an semicolon there to indicate that the user should keep chaining methods.

If you think that we should have semicolons for those previous examples too, please let me know to update this PR.

Thank you all ❤️