### PR TITLE
Add to.not.redirect example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Assert that a `Response` object has a redirect status code.
 
 ```js
 expect(res).to.redirect;
+expect(res).to.not.redirect;
 ```
 
 ### .redirectTo


### PR DESCRIPTION
Many of the other examples show `.not` variations, updated `.redirect` to be consistent