### PR TITLE
Make it easier to find out how to login during tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ chai.use(require('chai-http'));
 #### Retaining cookies with each request
 
 Sometimes you need to keep cookies from one request, and send them with the
-next. For this, `.request.agent()` is available:
+next (for example, when you want to login with the first request, then access an authenticated-only resource later). For this, `.request.agent()` is available:
 
 ```js
 // Log in


### PR DESCRIPTION
Just dropped the "login" keyword in the guide to make it easier to discover by new users searching for it.