### PR TITLE
Fix 178

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ chai.request(app)
   .get('/')
 ```
 
+When passing an `app` to `request`; it will automatically open the server for
+incoming requests (by calling `listen()`) and, once a request has been made
+the server will automatically shut down (by calling `.close()`). If you want to
+keep the server open, perhaps if you're making multiple requests, you must call
+`.keepOpen()` after `.request()`, and manually close the server down:
+
+```js
+var requester = chai.request(app).keepOpen()
+
+Promise.all([
+  requester.get('/a'),
+  requester.get('/b'),
+])
+.then(responses => ....)
+.then(() => requester.close())
+```
+
+
 #### URL
 
 You may also use a base url as the foundation of your request.

--- a/lib/request.js
+++ b/lib/request.js
@@ -214,13 +214,31 @@ module.exports = function (app) {
       : app
     , obj = {};
 
+  var keepOpen = false
+  if (typeof server !== 'string' && server && server.listen && server.address) {
+    if (!server.address()) {
+      server = server.listen(0)
+    }
+  }
+  obj.keepOpen = function() {
+    keepOpen = true
+    return this
+  }
+  obj.close = function(callback) {
+    if (server && server.close && keepOpen === false) {
+      server.close(callback);
+    }
+    return this
+  }
   methods.forEach(function (method) {
     obj[method] = function (path) {
-      return new Test(server, method, path);
+      return new Test(server, method, path)
+        .on('end', function() {
+          obj.close();
+        });
     };
   });
   obj.del = obj.delete;
-
   return obj;
 };
 
@@ -257,8 +275,7 @@ function serverAddress (app, path) {
   }
   var addr = app.address();
   if (!addr) {
-    app.listen(0);
-    addr = app.address();
+    throw new Error('Server is not listening')
   }
   var protocol = (app instanceof https.Server) ? 'https' : 'http';
   // If address is "unroutable" IPv4/6 address, then set to localhost
@@ -286,8 +303,21 @@ function TestAgent(app) {
   if (typeof app === 'function') app = http.createServer(app);
   (Agent || Request).call(this);
   this.app = app;
+  if (typeof app !== 'string' && app && app.listen && app.address && !app.address()) {
+    this.app = app.listen(0)
+  }
 }
 util.inherits(TestAgent, Agent || Request);
+
+TestAgent.prototype.close = function close(callback) {
+  if (this.app && this.app.close) {
+    this.app.close(callback)
+  }
+  return this
+}
+TestAgent.prototype.keepOpen = function keepOpen() {
+  return this
+}
 
 // override HTTP verb methods
 methods.forEach(function(method){

--- a/package.json
+++ b/package.json
@@ -47,10 +47,10 @@
     "querystring": "qs"
   },
   "dependencies": {
-    "cookiejar": "2.1.0",
-    "is-ip": "1.0.0",
+    "cookiejar": "^2.1.1",
+    "is-ip": "^2.0.0",
     "methods": "^1.1.2",
-    "qs": "^6.2.0",
+    "qs": "^6.5.1",
     "superagent": "^3.7.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -54,15 +54,15 @@
     "superagent": "^3.7.0"
   },
   "devDependencies": {
-    "simplifyify": "^2.0.1",
     "chai": "4",
-    "coveralls": "^2.11.9",
-    "dox": "^0.8.1",
+    "coveralls": "^3.0.0",
+    "dox": "^0.9.0",
     "es6-shim": "^0.35.1",
-    "http-server": "^0.9.0",
+    "http-server": "^0.10.0",
     "istanbul": "^0.4.3",
-    "mocha": "^3.0.2",
-    "npm-run-all": "^3.0.0"
+    "mocha": "^4.0.1",
+    "npm-run-all": "^4.1.1",
+    "simplifyify": "^3.2.4"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
In preparing for a release I noticed the severity of #178 was affecting our own test suite, so I decided to fix it. The commit description should hopefully provide context:

> This automatically closes server connections after making a request; so that test runners (like mocha 4) aren't left hanging after the test execution. If someone really needs to keep the server open, `.keepOpen()` can be used.

> Fixes #178

> BREAKING CHANGE:

> This change closes servers down after every request. If you want to use the server for reasons at the same time as your test suite or for some other reason you dont want the server to automatically be shut-down, then you'll need to change any `chai.request` callsites to also use the `keepOpen` comand, like so:

> ```js
> chai.request(server).keepOpen()
> ```

