### PR TITLE
use exported methods rather than encapsulated ones

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -232,7 +232,7 @@ module.exports = function (app) {
   }
   methods.forEach(function (method) {
     obj[method] = function (path) {
-      return new Test(server, method, path)
+      return new module.exports.Test(server, method, path)
         .on('end', function() {
           obj.close();
         });
@@ -299,7 +299,7 @@ function serverAddress (app, path) {
  */
 
 function TestAgent(app) {
-  if (!(this instanceof TestAgent)) return new TestAgent(app);
+  if (!(this instanceof module.exports.agent)) return new module.exports.agent(app);
   if (typeof app === 'function') app = http.createServer(app);
   (Agent || Request).call(this);
   this.app = app;
@@ -322,7 +322,7 @@ TestAgent.prototype.keepOpen = function keepOpen() {
 // override HTTP verb methods
 methods.forEach(function(method){
   TestAgent.prototype[method] = function(url){
-    var req = new Test(this.app, method, url)
+    var req = new module.exports.Test(this.app, method, url)
       , self = this;
 
     if (Agent) {


### PR DESCRIPTION
In the `/lib/request.js` module, these methods are exported:
```javascript
module.exports.Test = Test;
module.exports.Request = Test;
module.exports.agent = TestAgent;
```

Exporting these methods gives the benefit for those who need extra functionality to extend these methods as needed. However, the inner code does not use these exported modules, rather it uses the private ones (ie `Test` directly) this handicapes the feature, as extending the exported methods practically does nothing.

The proposed implementation can be seen on major code bases such as `node` and `mocha`; so i believe its a better practice over all.

P.S. i needed to override `Test` module to add extra logging on each request sent, but overriding the Test method does nothing.
  