### PR TITLE
Fix(request-helper):  return new Test

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -222,20 +222,19 @@ module.exports = function (app) {
   }
   obj.keepOpen = function() {
     keepOpen = true
-    return this
+    return obj
   }
   obj.close = function(callback) {
     if (server && server.close && keepOpen === false) {
       server.close(callback);
     }
-    return this
+    return obj
   }
   methods.forEach(function (method) {
     obj[method] = function (path) {
-      return new Test(server, method, path)
-        .on('end', function() {
-          obj.close();
-        });
+      const test = new Test(server, method, path);
+      test.on('end', obj.close);
+      return test;
     };
   });
   obj.del = obj.delete;


### PR DESCRIPTION
I was testing the master code on my company's code base, and It was not working because of this changed line of code:

```
return new Test(server, method, path)
   .on('end', function() {
       obj.close();
    });
```

This is the error:

> TypeError: Cannot read property 'address' of undefined
>      at serverAddress (request.js)
>      at new Test (request.js)
>      at Object.obj.(anonymous function) [as get] (request.js)
>      at Context.<anonymous> (<testing file>.spec.js)

I have the following setup:

```javascript
global.reflowRequest = () => request(process.env.AUTOMATION_MANAGER_API);

//...

const req = reflowRequest().get(url);

return expect(req).to.eventually.be.fulfilled...
```

The fix proposed solved this issue for me