### PR TITLE
chore(package): fixed license typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0",
   "description": "Extend Chai Assertion library with tests for http apis",
   "author": "Jake Luer <jake@alogicalparadox.com>",
-  "licence": "MIT",
+  "license": "MIT",
   "keywords": [
     "chai",
     "chai-plugin",


### PR DESCRIPTION
the license property of the package.json was misspelled, making it hard for tools like license-crawler and the likes to fetch the used license