### PR TITLE
Enable closing after "keepOpen()" has been called

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -225,16 +225,22 @@ module.exports = function (app) {
     return this
   }
   obj.close = function(callback) {
-    if (server && server.close && keepOpen === false) {
+    if (server && server.close) {
       server.close(callback);
     }
+    else if(callback) {
+      callback();
+    }
+    
     return this
   }
   methods.forEach(function (method) {
     obj[method] = function (path) {
       return new Test(server, method, path)
         .on('end', function() {
-          obj.close();
+          if(keepOpen === false) {
+            obj.close();
+          }
         });
     };
   });

--- a/test/request.js
+++ b/test/request.js
@@ -205,7 +205,19 @@ describe('request', function () {
       });
     });
 
+  it('can close server after using keepOpen()', function (done) {
+    var server = require('http').createServer(function (req, res) {
+      res.writeHeader(200, { 'content-type' : 'text/plain' });
+      res.end('hello world');
+    });
+    var cachedRequest = request(server).keepOpen();
+    cachedRequest.close(function (err) {
+      should.not.exist(server.address());
+      done();
+    });
   });
+
+});
 
   isBrowser && describe('Browser', function () {
     it('cannot request a functioned "app"', function () {


### PR DESCRIPTION
Test and changes to request to allow `.keepOpen()` request to actually close, fixes #189.

FYI Side Note - I had to disable posttest `script` during local development as it causes `npm test` to fail (I have no token) with:

```sh
> if [ -z "$COVERALLS_REPO_TOKEN" ]; then cat coverage/lcov.info | coveralls; fi

/Users/marty/dev/chai-http/node_modules/coveralls/bin/coveralls.js:18
        throw err;
        ^
Bad response: 422 {"message":"Couldn't find a repository matching this job.","error":true}
```