### PR TITLE
ci: build before release, commit assets, remove .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-
-//registry.npmjs.org/:_authToken = ${NPM_TOKEN}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,7 +5,10 @@
     "@semantic-release/changelog",
     "@semantic-release/npm",
     "@semantic-release/github",
-    "@semantic-release/git"
+    ["@semantic-release/git", {
+      "assets": ["dist/*", "package.json", "CHANGELOG.md", "package-lock.json"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }]
   ],
   "tagFormat": "${version}"
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ jobs:
       node_js: 10
       script: skip
       env:
-        # GitHub
-        - secure: "brL77ysx1Z30fGqeTLtdhVYCdMXFi6kbQYpQB2w9CtJJeI9zKZDagYKSjHpY1kzgUN0BoXG/Kyr1EgXsE2nBHjWYPKsxcbNP8gEAl8I6J7LBNVrxYkJNzQ46jYIjtjAWwodbQGAz0LrH5b8sw8IwE8vcxZ4thfZupA50LC8VdWA="
         # NPM
-        - secure: "fM77hue6ws/ikKaCzUsy6o3urxBHH0YjNSP3Dzc1Qm6oBthe8AYMifV7O93JI3T9ne4jDJvXcCCxgCOBr7gYr7U2/W+X144MphuBbqlTRxusKKBYCtK0QatjM9Px07f1lWLhgcEbwAayr9l9JSSJk4y5T7zk0Ij02gHapB0PPv8="
+        - secure: fM77hue6ws/ikKaCzUsy6o3urxBHH0YjNSP3Dzc1Qm6oBthe8AYMifV7O93JI3T9ne4jDJvXcCCxgCOBr7gYr7U2/W+X144MphuBbqlTRxusKKBYCtK0QatjM9Px07f1lWLhgcEbwAayr9l9JSSJk4y5T7zk0Ij02gHapB0PPv8=
+        # GitHub
+        - secure: brL77ysx1Z30fGqeTLtdhVYCdMXFi6kbQYpQB2w9CtJJeI9zKZDagYKSjHpY1kzgUN0BoXG/Kyr1EgXsE2nBHjWYPKsxcbNP8gEAl8I6J7LBNVrxYkJNzQ46jYIjtjAWwodbQGAz0LrH5b8sw8IwE8vcxZ4thfZupA50LC8VdWA=
       deploy:
         provider: script
         skip_cleanup: true

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "server": "http-server -o -c-1",
     "test": "istanbul cover --report lcovonly _mocha",
     "coverage": "if [ -z \"$COVERALLS_REPO_TOKEN\" ]; then cat coverage/lcov.info | coveralls; fi",
-    "release": "semantic-release"
+    "release": "npm run build && semantic-release"
   },
   "browser": {
     "http": false,


### PR DESCRIPTION
More (and hopefully last) tweaks for semantic releasing:
- builds in the release step, and [adds the files to the release commit](https://github.com/semantic-release/git#usage).
- removes `.npmrc` so we don't need an `NPM_TOKEN` for every stage, and the [npm semantic-release plugin will dynamically create one](https://github.com/semantic-release/npm#semantic-releasenpm) when needed.

I've figured out why the `NPM_TOKEN` isn't be correctly set as well: previously we were using the Travis npm deploy, where just the API key was encrypted, but now we need it to be an environment variable with a name. I don't have publish rights to npm, but can someone generate a token and then encrypt it like this?
```sh
travis encrypt NPM_TOKEN=$NPM_TOKEN
``` 

Also, can we remove the Sauce [travis env variables](https://travis-ci.org/chaijs/chai-http/settings)?
