### PR TITLE
Adds cookie attribute assertions (fixes #259)

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,19 +390,46 @@ expect(req).to.not.have.param('limit');
 
 ### .cookie
 
-* **@param** _{String}_ parameter name
+* **@param** _{String}_ parameter key
 * **@param** _{String}_ parameter value
+* **@param** _{String}_ parameter attributes
 
 Assert that a `Request` or `Response` object has a cookie header with a
-given key, (optionally) equal to value
+given key, (optionally) equal to value and (also optionally) with the given
+attributes.
+
+This assertion changes the context of the assertion to the cookie itself,
+allowing chaining assertions about the cookie.
 
 ```js
 expect(req).to.have.cookie('session_id');
 expect(req).to.have.cookie('session_id', '1234');
 expect(req).to.not.have.cookie('PHPSESSID');
+
 expect(res).to.have.cookie('session_id');
 expect(res).to.have.cookie('session_id', '1234');
+expect(res).to.have.cookie('session_id', '1234', {'Path': '/'});
 expect(res).to.not.have.cookie('PHPSESSID');
+```
+
+### .attribute (chainable after .cookie)
+
+* **@param** _{String}_ parameter attr
+* **@param** _{String}_ parameter expected
+
+Asserts that a cookie has a certain attribute `attr` equals to the value
+`expected`. In case of boolean cookie flags (like HttpOnly and Secure), the
+value can be omitted and the flag existence will be asserted instead.
+
+```js
+expect(res).to.have.cookie('sessid').with.attribute('Path', '/');
+expect(res).to.have.cookie('sessid').with.attribute('Secure');
+
+expect(res).to.have.cookie('sessid')
+  .with.attribute('Path', '/')
+  .and.with.attribute('Domain', '.abc.xyz');
+
+expect(res).to.have.cookie('sessid').but.not.with.attribute('HttpOnly');
 ```
 
 ## Releasing

--- a/lib/http.js
+++ b/lib/http.js
@@ -456,7 +456,28 @@ module.exports = function (chai, _) {
     var cookieCtx = new Assertion();
     transferFlags(this, cookieCtx);
     flag(cookieCtx, 'object', cookie);
+    flag(cookieCtx, 'key', key);
     return cookieCtx;
+  });
+
+  Assertion.overwriteMethod('attribute', function (_super) {
+    return function(attr, expected) {
+      if (this._obj instanceof Cookie.Cookie) {
+        var cookie = this._obj;
+        var key = flag(this, 'key');
+        var actual = cookie[attr.toLowerCase()]
+
+        this.assert(
+            actual === expected
+          , "cookie '" + key + "' expected #{exp} but got #{act}"
+          , "cookie '" + key + "' expected attribute to not be #{exp}"
+          , attr + '=' + expected
+          , attr + '=' + actual
+        );
+      } else {
+        _super.apply(this, arguments);
+      }
+    }
   });
 
   function normalizeKeys(obj) {

--- a/lib/http.js
+++ b/lib/http.js
@@ -416,22 +416,13 @@ module.exports = function (chai, _) {
       cookie = cookie.getCookie(key, Cookie.CookieAccessInfo.All);
     }
 
-    if (arguments.length >= 2) {
-      this.assert(
-          cookie.value == value
-        , 'expected cookie \'' + key + '\' to have value #{exp} but got #{act}'
-        , 'expected cookie \'' + key + '\' to not have value #{exp}'
-        , value
-        , cookie.value
-      );
-    } else {
-      this.assert(
-          'undefined' !== typeof cookie || null === cookie
-        , 'expected cookie \'' + key + '\' to exist'
-        , 'expected cookie \'' + key + '\' to not exist'
-      );
-    }
-
+    // Unfortunatelly, we can't fully rely on the Cookie object retrieved
+    // above, as the library doesn't have support to some cookie attributes,
+    // like the `Max-Age`. Also, it uses some defaults, which are totally
+    // fine, but would affect the assertions and potentially give false
+    // positives (Path=/, for example, would pass the assertion, even if not
+    // set in the original cookie).
+    // For these reasons, we collect the raw cookie to parse it manually.
     var rawCookie = '';
     header.forEach(function(cookieHeader) {
       if (cookieHeader.startsWith(key + '=')) {
@@ -439,29 +430,54 @@ module.exports = function (chai, _) {
       }
     });
 
-    // .toString() implementation of Cookie actually makes some
-    // cookie attributes to disappear (like Max-Age, for example).
-    // We use this value only as a fallback (it's better than nothing).
+    // If the above failed, we use this string representation of Cookie as a
+    // fallback. It's better than nothing...
     if (!rawCookie && cookie instanceof Cookie.Cookie) {
       rawCookie = cookie.toString();
     }
 
-    if ('object' === typeof attributes) {
-      var pass = true;
+    // First check: cookie existence
+    var cookieExists = 'undefined' !== typeof cookie || null === cookie;
 
-      Object.keys(attributes).forEach(function(attr) {
+    // Second check: cookie value correctness
+    var isValueCorrect = true;
+    if (arguments.length >= 2) {
+      isValueCorrect = cookieExists && cookie.value == value;
+    }
+
+    // Third check: all the cookie attributes should match
+    var areAttributesCorrect = isValueCorrect;
+    if (arguments.length >= 3 && 'object' === typeof attributes) {
+      // null can still be an object...
+      Object.keys(attributes || {}).forEach(function(attr) {
         var expected = attributes[attr];
         var actual = getCookieAttribute(rawCookie, attr);
-        if (actual !== expected) pass = false;
+        areAttributesCorrect = areAttributesCorrect && actual === expected;
       });
+    }
 
+    if (arguments.length === 3) {
       this.assert(
-          pass
+          areAttributesCorrect
         , "expected cookie '" + key + "' to have the following attributes:"
         , "expected cookie '" + key + "' to not have the following attributes:"
         , normalizeKeys(attributes)
         , rawCookieToObj(rawCookie)
         , true
+      );
+    } else if (arguments.length === 2) {
+      this.assert(
+          isValueCorrect
+        , 'expected cookie \'' + key + '\' to have value #{exp} but got #{act}'
+        , 'expected cookie \'' + key + '\' to not have value #{exp}'
+        , value
+        , cookie.value
+      );
+    } else {
+      this.assert(
+          cookieExists
+        , 'expected cookie \'' + key + '\' to exist'
+        , 'expected cookie \'' + key + '\' to not exist'
       );
     }
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -28,6 +28,8 @@ module.exports = function (chai, _) {
    */
 
   var Assertion = chai.Assertion
+    , flag = chai.util.flag
+    , transferFlags = chai.util.transferFlags
     , i = _.inspect;
 
   /*!
@@ -448,6 +450,13 @@ module.exports = function (chai, _) {
         , true
       );
     }
+
+    // Change the assertion context to the cookie itself,
+    // in order to make chaining possible
+    var cookieCtx = new Assertion();
+    transferFlags(this, cookieCtx);
+    flag(cookieCtx, 'object', cookie);
+    return cookieCtx;
   });
 
   function normalizeKeys(obj) {

--- a/lib/http.js
+++ b/lib/http.js
@@ -461,7 +461,7 @@ module.exports = function (chai, _) {
           areAttributesCorrect
         , "expected cookie '" + key + "' to have the following attributes:"
         , "expected cookie '" + key + "' to not have the following attributes:"
-        , normalizeKeys(attributes)
+        , prepareAttributesOutput(attributes, key, value)
         , rawCookieToObj(rawCookie)
         , true
       );
@@ -540,8 +540,9 @@ module.exports = function (chai, _) {
     return obj;
   }
 
-  function normalizeKeys(obj) {
+  function prepareAttributesOutput(obj, key, value) {
     var newObj = {};
+    newObj[key] = value;
     Object.keys(obj).forEach(function(key) {
       newObj[key.toLowerCase()] = obj[key];
     });

--- a/lib/http.js
+++ b/lib/http.js
@@ -437,7 +437,7 @@ module.exports = function (chai, _) {
 
       Object.keys(attributes).forEach(function(attr) {
         var expected = attributes[attr];
-        var actual = cookie[attr.toLowerCase()]
+        var actual = getCookieAttribute(cookie, attr);
         if (actual !== expected) pass = false;
       });
 
@@ -465,7 +465,11 @@ module.exports = function (chai, _) {
       if (this._obj instanceof Cookie.Cookie) {
         var cookie = this._obj;
         var key = flag(this, 'key');
-        var actual = cookie[attr.toLowerCase()]
+        var actual = getCookieAttribute(cookie, attr);
+
+        // If only one argument was passed, we are checking
+        // for a boolean attribute
+        if (arguments.length === 1) expected = true;
 
         this.assert(
             actual === expected
@@ -479,6 +483,16 @@ module.exports = function (chai, _) {
       }
     }
   });
+
+  function getCookieAttribute(cookie, attr) {
+    attr = attr.toLowerCase();
+
+    // In the Cookie class, the standard 'HttpOnly' attribute is parsed
+    // as a non-standard 'noscript' attribute...
+    if (attr === 'httponly') return cookie.noscript;
+
+    return cookie[attr];
+  }
 
   function normalizeKeys(obj) {
     var newObj = {};

--- a/lib/http.js
+++ b/lib/http.js
@@ -367,28 +367,38 @@ module.exports = function (chai, _) {
   /**
    * ### .cookie
    *
-   * Assert that a `Request`, `Response` or `Agent` object has a cookie header with a
-   * given key, (optionally) equal to value
+   * Assert that a `Request`, `Response` or `Agent` object has a cookie header
+   * with a given key. Optionally, the value and attributes of the cookie can
+   * also be checked. Usually, asserting cookie attributes only makes sense
+   * when in the context of the `Response` object. Attribute key comparison is
+   * case insensitive.
    *
    * ```js
    * expect(req).to.have.cookie('session_id');
    * expect(req).to.have.cookie('session_id', '1234');
    * expect(req).to.not.have.cookie('PHPSESSID');
+   *
    * expect(res).to.have.cookie('session_id');
    * expect(res).to.have.cookie('session_id', '1234');
+   * expect(res).to.have.cookie('session_id', '1234', {
+   *   'Path': '/',
+   *   'Domain': '.abc.xyz'
+   * });
    * expect(res).to.not.have.cookie('PHPSESSID');
+   *
    * expect(agent).to.have.cookie('session_id');
    * expect(agent).to.have.cookie('session_id', '1234');
    * expect(agent).to.not.have.cookie('PHPSESSID');
    * ```
    *
-   * @param {String} parameter name
+   * @param {String} parameter key
    * @param {String} parameter value
+   * @param {Object} parameter attributes
    * @name param
    * @api public
    */
 
-  Assertion.addMethod('cookie', function (key, value) {
+  Assertion.addMethod('cookie', function (key, value, attributes) {
     var header = getHeader(this._obj, 'set-cookie')
       , cookie;
 
@@ -404,7 +414,7 @@ module.exports = function (chai, _) {
       cookie = cookie.getCookie(key, Cookie.CookieAccessInfo.All);
     }
 
-    if (arguments.length === 2) {
+    if (arguments.length >= 2) {
       this.assert(
           cookie.value == value
         , 'expected cookie \'' + key + '\' to have value #{exp} but got #{act}'
@@ -419,5 +429,32 @@ module.exports = function (chai, _) {
         , 'expected cookie \'' + key + '\' to not exist'
       );
     }
+
+    if ('object' === typeof attributes) {
+      var pass = true;
+
+      Object.keys(attributes).forEach(function(attr) {
+        var expected = attributes[attr];
+        var actual = cookie[attr.toLowerCase()]
+        if (actual !== expected) pass = false;
+      });
+
+      this.assert(
+          pass
+        , "expected cookie '" + key + "' to have the following attributes:"
+        , "expected cookie '" + key + "' to not have the following attributes:"
+        , normalizeKeys(attributes)
+        , cookie
+        , true
+      );
+    }
   });
+
+  function normalizeKeys(obj) {
+    var newObj = {};
+    Object.keys(obj).forEach(function(key) {
+      newObj[key.toLowerCase()] = obj[key];
+    });
+    return newObj;
+  }
 };

--- a/lib/http.js
+++ b/lib/http.js
@@ -432,12 +432,26 @@ module.exports = function (chai, _) {
       );
     }
 
+    var rawCookie = '';
+    header.forEach(function(cookieHeader) {
+      if (cookieHeader.startsWith(key + '=')) {
+        rawCookie = cookieHeader;
+      }
+    });
+
+    // .toString() implementation of Cookie actually makes some
+    // cookie attributes to disappear (like Max-Age, for example).
+    // We use this value only as a fallback (it's better than nothing).
+    if (!rawCookie && cookie instanceof Cookie.Cookie) {
+      rawCookie = cookie.toString();
+    }
+
     if ('object' === typeof attributes) {
       var pass = true;
 
       Object.keys(attributes).forEach(function(attr) {
         var expected = attributes[attr];
-        var actual = getCookieAttribute(cookie, attr);
+        var actual = getCookieAttribute(rawCookie, attr);
         if (actual !== expected) pass = false;
       });
 
@@ -446,7 +460,7 @@ module.exports = function (chai, _) {
         , "expected cookie '" + key + "' to have the following attributes:"
         , "expected cookie '" + key + "' to not have the following attributes:"
         , normalizeKeys(attributes)
-        , cookie
+        , rawCookieToObj(rawCookie)
         , true
       );
     }
@@ -456,6 +470,7 @@ module.exports = function (chai, _) {
     var cookieCtx = new Assertion();
     transferFlags(this, cookieCtx);
     flag(cookieCtx, 'object', cookie);
+    flag(cookieCtx, 'rawCookie', rawCookie);
     flag(cookieCtx, 'key', key);
     return cookieCtx;
   });
@@ -465,7 +480,8 @@ module.exports = function (chai, _) {
       if (this._obj instanceof Cookie.Cookie) {
         var cookie = this._obj;
         var key = flag(this, 'key');
-        var actual = getCookieAttribute(cookie, attr);
+        var rawCookie = flag(this, 'rawCookie');
+        var actual = getCookieAttribute(rawCookie, attr);
 
         // If only one argument was passed, we are checking
         // for a boolean attribute
@@ -484,14 +500,28 @@ module.exports = function (chai, _) {
     }
   });
 
-  function getCookieAttribute(cookie, attr) {
-    attr = attr.toLowerCase();
+  function getCookieAttribute(rawCookie, attr) {
+    // Try to capture attribute with value
+    var pattern = new RegExp('(?<=^|;) ?' + attr + '=([^;]+)(?:;|$)', 'i');
+    var matches = rawCookie.match(pattern);
+    if (matches) return matches[1];
 
-    // In the Cookie class, the standard 'HttpOnly' attribute is parsed
-    // as a non-standard 'noscript' attribute...
-    if (attr === 'httponly') return cookie.noscript;
+    // If it didn't match the previous line, it can still be a boolean
+    pattern = new RegExp('(?<=^|;) ?' + attr + '(?:;|$)', 'i');
+    matches = rawCookie.match(pattern);
+    if (matches) return true;
 
-    return cookie[attr];
+    return false;
+  }
+
+  function rawCookieToObj(rawCookie) {
+    var obj = {};
+    rawCookie.split(';').forEach(function(pair) {
+      var entry = pair.trim().split('=');
+      var key = entry[0].toLowerCase();
+      obj[key] = entry[1] ? entry[1] : true;
+    });
+    return obj;
   }
 
   function normalizeKeys(obj) {

--- a/lib/http.js
+++ b/lib/http.js
@@ -375,6 +375,9 @@ module.exports = function (chai, _) {
    * when in the context of the `Response` object. Attribute key comparison is
    * case insensitive.
    *
+   * This assertion changes the context of the assertion to the cookie itself
+   * in order to allow chaining with cookie specific assertions (see below).
+   *
    * ```js
    * expect(req).to.have.cookie('session_id');
    * expect(req).to.have.cookie('session_id', '1234');
@@ -491,6 +494,40 @@ module.exports = function (chai, _) {
     return cookieCtx;
   });
 
+  /**
+   * ### .attribute
+   *
+   * Assert existence or value of a cookie attribute. It requires to be
+   * chained after previous assertion about cookie existence or key/value.
+   *
+   * As this method doesn't change the assertion context, it can be chained
+   * multiple times.
+   *
+   * This method is created using `overwriteMethod` in order to avoid
+   * conflicts with other chai libraries potentially implementing custom
+   * assertions with the name "attribute". Of course, the other library
+   * would have to do the same, but here we are doing our part :)
+   *
+   * ```js
+   * expect(res).to.have.cookie('session_id')
+   *   .with.attribute('Path', '/foo');
+   *
+   * expect(res).to.have.cookie('session_id')
+   *   .with.attribute('Path', '/foo')
+   *   .and.with.attribute('Domain', '.abc.xyz');
+   *
+   * expect(res).to.have.cookie('session_id', '123')
+   *   .with.attribute('HttpOnly');
+   *
+   * expect(res).to.have.cookie('session_id')
+   *   .but.not.with.attribute('HttpOnly');
+   * ```
+   *
+   * @param {String} attr
+   * @param {String} [expected=true]
+   * @api public
+   */
+
   Assertion.overwriteMethod('attribute', function (_super) {
     return function(attr, expected) {
       if (this._obj instanceof Cookie.Cookie) {
@@ -530,16 +567,35 @@ module.exports = function (chai, _) {
     return false;
   }
 
+  /**
+   * Prepares the raw cookie for the assertion failure output. All the keys
+   * will be converted to lowercase, with exception of the cookie key. The
+   * values won't pass through any conversion.
+   *
+   * @param {String} rawCookie
+   */
   function rawCookieToObj(rawCookie) {
     var obj = {};
-    rawCookie.split(';').forEach(function(pair) {
+    rawCookie.split(';').forEach(function(pair, index) {
       var entry = pair.trim().split('=');
-      var key = entry[0].toLowerCase();
+      // We shouldn't convert the case of the first key (the cookie key)
+      var key = index === 0 ? entry[0] : entry[0].toLowerCase();
       obj[key] = entry[1] ? entry[1] : true;
     });
     return obj;
   }
 
+  /**
+   * This function prepares the "attributes" object (passed as an argument
+   * to .cookie(...)) for the assertion failure output. All keys are converted
+   * to lowercase and the cookie key/value is added to the output (without
+   * case convertion) in order to make inspection of the failure easier.
+   *
+   * @param {Object} attributes
+   * @param {String} key - the cookie key
+   * @param {String} value - the expected cookie value
+   * @api private
+   */
   function prepareAttributesOutput(obj, key, value) {
     var newObj = {};
     newObj[key] = value;

--- a/test/http.js
+++ b/test/http.js
@@ -468,5 +468,87 @@ describe('assertions', function () {
         );
       });
     });
+
+    describe('as chainable method after #cookie(key, val)', function () {
+      var res = resWithCookie('sessid=abc; Path=/; Domain=.abc.xyz');
+
+      it('should match required attribute', function () {
+        res.should.have.cookie('sessid', 'abc').with.attribute('Path', '/');
+        res.should.have.cookie('sessid', 'abc').with.attribute('Domain', '.abc.xyz');
+      });
+
+      it('should allow multiple chained attributes', function () {
+        res.should.have.cookie('sessid', 'abc')
+          .with.attribute('Path', '/')
+          .and.with.attribute('Domain', '.abc.xyz');
+      });
+
+      it('should throw in case of failure', function () {
+        (function () {
+          res.should.have.cookie('sessid', 'abc').with.attribute('Path', '/wrong');
+        }).should.throw(
+          "cookie 'sessid' expected 'Path=/wrong' but got 'Path=/'"
+        );
+      });
+
+      it('should work with negation', function () {
+        res.should.have.cookie('sessid', 'abc')
+          .but.not.with.attribute('Path', '/foo');
+
+        res.should.have.cookie('sessid', 'abc')
+          .but.not.with.attribute('Domain', '.mno.efg');
+      });
+
+      it('should throw in case of negated failure', function () {
+        (function () {
+          res.should.have.cookie('sessid', 'abc')
+            .but.not.with.attribute('Path', '/');
+        }).should.throw(
+          "cookie 'sessid' expected attribute to not be 'Path=/'"
+        );
+      });
+    });
+
+    describe('as chainable method after #cookie(key)', function () {
+      var res = resWithCookie('sessid=abc; Path=/; Domain=.abc.xyz');
+
+      it('should match required attribute', function () {
+        res.should.have.cookie('sessid').with.attribute('Path', '/');
+        res.should.have.cookie('sessid').with.attribute('Domain', '.abc.xyz');
+      });
+
+      it('should allow multiple chained attributes', function () {
+        res.should.have.cookie('sessid')
+          .with.attribute('Path', '/')
+          .and.with.attribute('Domain', '.abc.xyz');
+      });
+
+      it('should throw in case of failure', function () {
+        (function () {
+          res.should.have.cookie('sessid').with.attribute('Path', '/wrong');
+        }).should.throw(
+          "cookie 'sessid' expected 'Path=/wrong' but got 'Path=/'"
+        );
+      });
+
+      it('should work with negation', function () {
+        var res = resWithCookie('sessid=abc; Path=/; Domain=.abc.xyz');
+
+        res.should.have.cookie('sessid')
+          .but.not.with.attribute('Path', '/foo');
+
+        res.should.have.cookie('sessid')
+          .but.not.with.attribute('Domain', '.mno.efg');
+      });
+
+      it('should throw in case of negated failure', function () {
+        (function () {
+          res.should.have.cookie('sessid')
+            .but.not.with.attribute('Path', '/');
+        }).should.throw(
+          "cookie 'sessid' expected attribute to not be 'Path=/'"
+        );
+      });
+    });
   });
 });

--- a/test/http.js
+++ b/test/http.js
@@ -328,6 +328,16 @@ describe('assertions', function () {
     }).should.throw('expected cookie \'name2\' to have value \'value\' but got \'value2\'');
   });
 
+  it('#cookie (changes assertion context)', function () {
+    var Cookie = require('cookiejar').Cookie;
+    var res = {
+      headers: {'set-cookie': ['name=value']}
+    };
+
+    var context = res.should.have.cookie('name');
+    context._obj.should.be.instanceof(Cookie);
+  });
+
   it('#cookie (request)', function () {
     var req = {
       headers: {

--- a/test/http.js
+++ b/test/http.js
@@ -474,6 +474,14 @@ describe('assertions', function () {
         res.should.have.cookie('sessid', 'abc', {'Secure': true});
         res.should.have.cookie('sessid', 'abc', {'HttpOnly': true});
       });
+
+      it('should work with time attributes (Expires, Max-Age)', function () {
+        var res = resWithCookie('sessid=abc; Expires=Wed, 15 Jun 2031 14:20:00 GMT; Max-Age=2592000');
+        res.should.have.cookie('sessid', 'abc', {'Max-Age': '2592000'});
+        res.should.have.cookie('sessid', 'abc', {
+          'Expires': 'Wed, 15 Jun 2031 14:20:00 GMT'
+        });
+      });
     });
 
     describe('as chainable method after #cookie(key, val)', function () {
@@ -488,6 +496,12 @@ describe('assertions', function () {
         var res = resWithCookie('sessid=abc; Domain=.abc.xyz; HttpOnly; Secure');
         res.should.have.cookie('sessid', 'abc').with.attribute('HttpOnly');
         res.should.have.cookie('sessid', 'abc').with.attribute('Secure');
+      });
+
+      it('should work with time attributes (Expires, Max-Age)', function () {
+        var res = resWithCookie('sessid=abc; Expires=Wed, 15 Jun 2031 14:20:00 GMT; Max-Age=2592000');
+        res.should.have.cookie('sessid', 'abc').with.attribute('Max-Age', '2592000');
+        res.should.have.cookie('sessid', 'abc').with.attribute('Expires', 'Wed, 15 Jun 2031 14:20:00 GMT');
       });
 
       it('should allow multiple chained attributes', function () {
@@ -534,6 +548,12 @@ describe('assertions', function () {
         var res = resWithCookie('sessid=abc; Domain=.abc.xyz; HttpOnly; Secure');
         res.should.have.cookie('sessid').with.attribute('HttpOnly');
         res.should.have.cookie('sessid').with.attribute('Secure');
+      });
+
+      it('should work with time attributes (Expires, Max-Age)', function () {
+        var res = resWithCookie('sessid=abc; Expires=Wed, 15 Jun 2031 14:20:00 GMT; Max-Age=2592000');
+        res.should.have.cookie('sessid').with.attribute('Max-Age', '2592000');
+        res.should.have.cookie('sessid').with.attribute('Expires', 'Wed, 15 Jun 2031 14:20:00 GMT');
       });
 
       it('should allow multiple chained attributes', function () {

--- a/test/http.js
+++ b/test/http.js
@@ -467,6 +467,13 @@ describe('assertions', function () {
           "expected cookie 'sessid' to have the following attributes:"
         );
       });
+
+      it('should work with boolean attributes (HttpOnly, Secure)', function () {
+        var res = resWithCookie('sessid=abc; Path=/; HttpOnly; Secure');
+
+        res.should.have.cookie('sessid', 'abc', {'Secure': true});
+        res.should.have.cookie('sessid', 'abc', {'HttpOnly': true});
+      });
     });
 
     describe('as chainable method after #cookie(key, val)', function () {
@@ -475,6 +482,12 @@ describe('assertions', function () {
       it('should match required attribute', function () {
         res.should.have.cookie('sessid', 'abc').with.attribute('Path', '/');
         res.should.have.cookie('sessid', 'abc').with.attribute('Domain', '.abc.xyz');
+      });
+
+      it('should work with boolean attributes (HttpOnly, Secure)', function () {
+        var res = resWithCookie('sessid=abc; Domain=.abc.xyz; HttpOnly; Secure');
+        res.should.have.cookie('sessid', 'abc').with.attribute('HttpOnly');
+        res.should.have.cookie('sessid', 'abc').with.attribute('Secure');
       });
 
       it('should allow multiple chained attributes', function () {
@@ -515,6 +528,12 @@ describe('assertions', function () {
       it('should match required attribute', function () {
         res.should.have.cookie('sessid').with.attribute('Path', '/');
         res.should.have.cookie('sessid').with.attribute('Domain', '.abc.xyz');
+      });
+
+      it('should work with boolean attributes (HttpOnly, Secure)', function () {
+        var res = resWithCookie('sessid=abc; Domain=.abc.xyz; HttpOnly; Secure');
+        res.should.have.cookie('sessid').with.attribute('HttpOnly');
+        res.should.have.cookie('sessid').with.attribute('Secure');
       });
 
       it('should allow multiple chained attributes', function () {

--- a/test/http.js
+++ b/test/http.js
@@ -432,4 +432,31 @@ describe('assertions', function () {
       }).should.throw('expected content type to have utf-8 charset');
     });
   });
+
+  describe('#cookie attributes', function () {
+    function resWithCookie(cookie) {
+      return {
+        headers: {'set-cookie': [cookie]}
+      };
+    }
+
+    describe('as additional argument to #cookie', function () {
+      it('only matches required attributes (ignores the rest)', function () {
+        var res = resWithCookie('sessid=abc; Path=/; Domain=.abc.xyz');
+
+        res.should.have.cookie('sessid', 'abc', {'Path': '/'});
+        res.should.have.cookie('sessid', 'abc', {'Domain': '.abc.xyz'});
+        res.should.have.cookie('sessid', 'abc', {
+          'Path': '/',
+          'Domain': '.abc.xyz',
+        });
+
+        (function () {
+          res.should.have.cookie('sessid', 'abc', {'Path': '/wrong'});
+        }).should.throw(
+          "expected cookie 'sessid' to have the following attributes:"
+        );
+      });
+    });
+  });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,7 +27,9 @@ declare global {
 
             param(key: string, value?: string): Assertion;
 
-            cookie(key: string, value?: string): Assertion;
+            cookie(key: string, value?: string, attributes?: Object): Assertion;
+
+            attribute(attr: string, expected?: string|boolean): Assertion;
 
             status(code: number): Assertion;
 


### PR DESCRIPTION
Please refer to the README and comments in the pull request for greater details. Basically, this is adding the possibility to pass an object as the third argument to `.cookie(...)` to assert about a certain subset of the cookie attributes, like `Path`, `Domain`, `Max-Age`, `HttpOnly`, and etc.

It also adds a new assertion method chainable after a cookie assertion, to assert about a single attribute in a more "chaiish" readable style.

This pull request addresses issue #259.