### PR TITLE
feat: status assert now outputs status code number and text

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -22,6 +22,7 @@ module.exports = function (chai, _) {
   var url = require('url');
   var Cookie = require('cookiejar');
   var charset = require("charset");
+  var statusCodes = require('http-status-codes');
 
   /*!
    * Aliases.
@@ -63,6 +64,21 @@ module.exports = function (chai, _) {
     if (obj.headers) return obj.headers[key];
   };
 
+  /*!
+   * Return a status code text from`Code` number. If code is not a valid http code it returns `Unknown`
+   *
+   * @param {Number} Code
+   * @returns {String}
+   */
+
+  function getStatusText(code) {
+    try {
+        return statusCodes.getStatusText(code);
+    } catch(error) {
+        return 'Unknown';
+    }
+  };
+
   /**
    * ### .status (code)
    *
@@ -94,8 +110,8 @@ module.exports = function (chai, _) {
         status == code
       , 'expected #{this} to have status code #{exp} but got #{act}'
       , 'expected #{this} to not have status code #{act}'
-      , code
-      , status
+      , code + ' (' + getStatusText(code) + ')'
+      , status + ' (' + getStatusText(status) + ')'
     );
   });
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/superagent": "^3.8.3",
     "charset": "^1.0.1",
     "cookiejar": "^2.1.1",
+    "http-status-codes": "^2.1.2",
     "is-ip": "^2.0.0",
     "methods": "^1.1.2",
     "qs": "^6.5.1",

--- a/test/http.js
+++ b/test/http.js
@@ -6,7 +6,11 @@ describe('assertions', function () {
 
     (function () {
       res.should.not.have.status(200);
-    }).should.throw('expected { status: 200 } to not have status code 200');
+    }).should.throw('expected { status: 200 } to not have status code \'200 (OK)\'');
+
+    (function () {
+      res.should.have.status(4004);
+    }).should.throw('expected { status: 200 } to have status code \'4004 (Unknown)\'');
 
     (function () {
       ({}).should.not.to.have.status(200);


### PR DESCRIPTION
Hello,

First of all, thanks for the chai-http. 

I have modified status assert error output to print status code as text as well as number. I've also modified tests and test are running fine.

However, I had to add http-status-codes package as new dependency in order to convert status code number to string. 

**Old behavior;**
```
      AssertionError: expected { Object (_events, _eventsCount, ...) } to have status code 200 but got 400
      + expected - actual

      -400
      +200
```

**New behavior;**
```
      AssertionError: expected { Object (_events, _eventsCount, ...) } to have status code '200 (OK)' but got '400 (Bad Request)'
      + expected - actual

      -400 (Bad Request)
      +200 (OK)
```

I've bored of to look up status codes on google so i guess this is a good feature to have.

Have a nice day,
Orcun