### PR TITLE
Added auth example with Bearer Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ chai.request(app)
 chai.request(app)
   .get('/protected')
   .auth('user', 'pass')
+  
+// Authenticate with Bearer Token
+chai.request(app)
+  .get('/protected')
+  .auth(accessToken, { type: 'bearer' })  
+  
 ```
 
 `.query()`


### PR DESCRIPTION
chai-http supports Authorization with Bearer Token. But, this feature is not mentioned anywhere on the site or readme file. 
This would be useful for many developers & Tester.

Ref: https://github.com/chaijs/chai-http/blob/master/dist/chai-http.js#L3359