### PR TITLE
ci: correctly template github event in `if` condition for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: coverallsapp/github-action@v1.0.1
         with:
           github-token: ${{ secrets.github_token }}
-        
+
 
   publish-npm:
     needs: build
@@ -40,7 +40,7 @@ jobs:
           node-version: 12
           registry-url: https://registry.npmjs.org/
       - run: npm run release
-        if: github.event == 'push'
+        if: ${{ github.event == 'push' }}
         env:
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}
           GITHUB_TOKEN: ${{secrets.github_token}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,5 +42,5 @@ jobs:
       - run: npm run release
         if: ${{ github.event == 'push' }}
         env:
-          NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_TOKEN: ${{secrets.NPM_TOKEN}} # f674......69f0
           GITHUB_TOKEN: ${{secrets.github_token}}


### PR DESCRIPTION
The last master run did not publish because of a faulty `if` clause.

see: https://github.com/chaijs/chai-http/actions/runs/596951264
see: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsif
