### PR TITLE
ci: use correct `event_name` property

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: 12
           registry-url: https://registry.npmjs.org/
       - run: npm run release
-        if: ${{ github.event == 'push' }}
+        if: ${{ github.event_name == 'push' }}
         env:
           NPM_TOKEN: ${{secrets.NPM_TOKEN}} # f674......69f0
           GITHUB_TOKEN: ${{secrets.github_token}}


### PR DESCRIPTION
It's `github.event_name`, not `github.event` :man_facepalming:.
