### PR TITLE
ci: install node deps before release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
+      - run: npm i -g npm@6 && npm ci
       - run: npm run release
         if: ${{ github.event_name == 'push' }}
         env:


### PR DESCRIPTION
Aaaaand anotha one. Could do caching, but would just like this to work first. Guess this is what happens when we update the CI and release system and don't use it for two years, hah.

Ran the build locally after a clean `npm ci` install and it succeeded.


https://github.com/chaijs/chai-http/runs/1972788417