### PR TITLE
Update CI release token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,4 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         env:
           NPM_TOKEN: ${{secrets.NPM_TOKEN}} # f674......69f0
-          GITHUB_TOKEN: ${{secrets.github_token}}
+          GITHUB_TOKEN: ${{secrets.GH_RELEASE_TOKEN}}


### PR DESCRIPTION
Following from https://github.com/chaijs/chai-http/pull/285 this uses a custom API token with Repo/Packages scopes to handle releases, separate from the `github_token`.