### PR TITLE
Update request.js

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -266,7 +266,7 @@ module.exports.agent = TestAgent;
  */
 
 function Test (app, method, path) {
-  method = method.toUpperCase(); // Do this in order to avoid "patch" beign sent as lowercase. 
+  method = method.toUpperCase(); // Do this in order to avoid "patch" being sent as lowercase. 
                                  // This makes the preflight request -when running in browser- to be sent as "Access-Control-Request-Method = patch" instead of "Access-Control-Request-Method = PATCH" 
                                  // Which causes problems with those kind of requests. For further reference: https://stackoverflow.com/questions/55250297/problem-with-patch-method-and-cors-preflight-request?rq=1 
   Request.call(this, method, path);


### PR DESCRIPTION
When running the tests in a browser with a PATCH type request, "PATCH" method is sent in all lower case letters. When the request uses CORS, the preflight OPTIONS is triggered before the actual request.  This request is sent with the following header: "Access-Control-Request-Method = patch" instead of "Access-Control-Request-Method = PATCH". This causes the "Access-Control-Allow-Methods = GET, POST, OPTIONS, PUT, PATCH, DELETE" to fail, because the expected method is "PATCH" instead of "patch". 
For further reading please refer to this stack overflow post: https://stackoverflow.com/questions/55250297/problem-with-patch-method-and-cors-preflight-request?rq=1