### PR TITLE
add ChaiHttp.Request to types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -50,6 +50,7 @@ declare global {
     }
 
     namespace ChaiHttp {
+        interface Request extends request.SuperAgentRequest {}
         interface Response extends request.Response {}
         interface Agent extends request.SuperAgentStatic {
             keepOpen(): Agent;


### PR DESCRIPTION
Suppose I assign a type to an unresolved chai http request in Typescript. Chai doesn't export a type, so the type has to be imported from superagent, which breaks encapsulation. This PR exports a wrapper type so that requests can be typed without an explicit dependency on superagent.

Before:
```typescript
import chai, { request } from 'chai'
import chaiHttp from 'chai-http'
import {SuperAgentRequest} from 'superagent' // breaks encapsulation

chai.use(chaiHttp)

let req: SuperAgentRequest
if (Math.random() < .5) {
	req = request('https://example.com').get('/')
}
else {
	req = request('https://other.com').get('/other')
}

req.set('Cookie', 'cookie=true')

```
After:
```typescript
import chai, { request } from 'chai'
import chaiHttp from 'chai-http'

chai.use(chaiHttp)

let req: ChaiHttp.Request
if (Math.random() < .5) {
	req = request('https://example.com').get('/')
}
else {
	req = request('https://other.com').get('/other')
}

req.set('Cookie', 'cookie=true')

```