### PR TITLE
refactor(request): abstract https server into a tls server for protocol checks

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -9,7 +9,7 @@
  */
 
 var http = require('http')
-  , https = require('https')
+  , tls = require('tls')
   , methods = require('methods')
   , superagent = require('superagent')
   , Agent = superagent.agent
@@ -283,7 +283,7 @@ function serverAddress (app, path) {
   if (!addr) {
     throw new Error('Server is not listening')
   }
-  var protocol = (app instanceof https.Server) ? 'https' : 'http';
+  var protocol = (app instanceof tls.Server) ? 'https' : 'http';
   // If address is "unroutable" IPv4/6 address, then set to localhost
   if (addr.address === '0.0.0.0' || addr.address === '::') {
     addr.address = '127.0.0.1';


### PR DESCRIPTION
The `TLS.Server` instance is common for both the `https` library and the `http2` library,
according to the NodeJS documentation. Since it is a common ancestor, we should check for
this instance instead of the specific `https` flavour.

On a similar note, the `net.Server` instance is common for both `http` and `http2` too,
though no changes are required to ensure they're cast to the same.

See the following links:
* https://nodejs.org/api/http.html#class-httpserver
* https://nodejs.org/api/http2.html#class-http2server
* https://nodejs.org/api/https.html#class-httpsserver
* https://nodejs.org/api/http2.html#class-http2secureserver