### PR TITLE
Fix: Pipeline push not working

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,5 +11,5 @@
     }]
   ],
   "tagFormat": "${version}",
-  "branches": ["+([0-9])?(.{+([0-9]),x}).x", "main", "next", "next-major", {"name": "beta", "prerelease": true}, {"name": 'alpha', "prerelease": true}]
+  "branches": ["+([0-9])?(.{+([0-9]),x}).x", "main", "next", "next-major", {"name": "beta", "prerelease": true}, {"name": "alpha", "prerelease": true}]
 }


### PR DESCRIPTION
To fix pipeline issues stopping chai-http from pushing new release.

Likely issue with the JSON parser not liking the single quotes, so just switched the quotes around alpha to double quotes.