### PR TITLE
Fix #326 - readme: add how to import chai 5 and use chaiHttp 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ const chaiHttp = require('chai-http');
 chai.use(chaiHttp);
 ```
 
+To use Chai HTTP in an ECMAScript module (ESM) 
+
+```js
+import chaiHttp from "chai-http";
+import * as chaiModule from 'chai';
+const chai = chaiModule.use(chaiHttp);
+```
+
 To use Chai HTTP on a web page, just include the [`dist/chai-http.js`](dist/chai-http.js) file:
 
 ```html


### PR DESCRIPTION
Fix #326 - readme: add how to import chai 5 and use chaiHttp 4