### PR TITLE
fix: update docs and types to expose `request`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ chai.use(chaiHttp);
 // if you need to access `request`
 import {default as chaiHttp, request} from "chai-http";
 chai.use(chaiHttp);
+
 request.get(...).send(...);
+
+// or setting up an app
+request.execute(app);
 ```
 
 To use Chai HTTP on a web page, please use the latest v4 version for now.
@@ -54,7 +58,9 @@ port to listen on for a given test.
 __Note:__ This feature is only supported on Node.js, not in web browsers.
 
 ```js
-chai.request.execute(app)
+import {request} from 'chai-http';
+
+request.execute(app)
   .get('/')
 ```
 
@@ -65,7 +71,9 @@ keep the server open, perhaps if you're making multiple requests, you must call
 `.keepOpen()` after `.request()`, and manually close the server down:
 
 ```js
-const requester = chai.request.Request(app).keepOpen()
+import {request} from 'chai-http';
+
+const requester = request.Request(app).keepOpen()
 
 Promise.all([
   requester.get('/a'),
@@ -81,7 +89,9 @@ Promise.all([
 You may also use a base url as the foundation of your request.
 
 ```js
-chai.request.execute('http://localhost:8080')
+import {request} from 'chai-http';
+
+request.execute('http://localhost:8080')
   .get('/')
 ```
 
@@ -102,8 +112,10 @@ Examples:
 
 `.set()`
 ```js
+import {request} from 'chai-http';
+
 // Set a request header
-chai.request.execute(app)
+request.execute(app)
   .put('/user/me')
   .set('Content-Type', 'application/json')
   .send({ password: '123', confirmPassword: '123' })
@@ -111,16 +123,20 @@ chai.request.execute(app)
 
 `.send()`
 ```js
+import {request} from 'chai-http';
+
 // Send some JSON
-chai.request.execute(app)
+request.execute(app)
   .put('/user/me')
   .send({ password: '123', confirmPassword: '123' })
 ```
 
 `.type()`
 ```js
+import {request} from 'chai-http';
+
 // Send some Form Data
-chai.request.execute(app)
+request.execute(app)
   .post('/user/me')
   .type('form')
   .send({
@@ -132,21 +148,25 @@ chai.request.execute(app)
 
 `.attach()`
 ```js
+import {request} from 'chai-http';
+
 // Attach a file
-chai.request.execute(app)
+request.execute(app)
   .post('/user/avatar')
   .attach('imageField', fs.readFileSync('avatar.png'), 'avatar.png')
 ```
 
 `.auth()`
 ```js
+import {request} from 'chai-http';
+
 // Authenticate with Basic authentication
-chai.request.execute(app)
+request.execute(app)
   .get('/protected')
   .auth('user', 'pass')
 
 // Authenticate with Bearer Token
-chai.request.execute(app)
+request.execute(app)
   .get('/protected')
   .auth(accessToken, { type: 'bearer' })
 
@@ -154,8 +174,10 @@ chai.request.execute(app)
 
 `.query()`
 ```js
+import {request} from 'chai-http';
+
 // Chain some GET query parameters
-chai.request.execute(app)
+request.execute(app)
   .get('/search')
   .query({name: 'foo', limit: 10}) // /search?name=foo&limit=10
 ```
@@ -171,7 +193,9 @@ const { expect } = chai;
 To make the request and assert on its response, the `end` method can be used:
 
 ```js
-chai.request.execute(app)
+import {request} from 'chai-http';
+
+request.execute(app)
   .put('/user/me')
   .send({ password: '123', confirmPassword: '123' })
   .end((err, res) => {
@@ -193,8 +217,10 @@ accomplished using the
 callback has completed, and the assertions can be verified:
 
 ```js
+import {request} from 'chai-http';
+
 it('fails, as expected', function(done) { // <= Pass in done callback
-  chai.request.execute('http://localhost:8080')
+  request.execute('http://localhost:8080')
   .get('/')
   .end((err, res) => {
     expect(res).to.have.status(123);
@@ -203,7 +229,7 @@ it('fails, as expected', function(done) { // <= Pass in done callback
 });
 
 it('succeeds silently!', () => {   // <= No done callback
-  chai.request.execute('http://localhost:8080')
+  request.execute('http://localhost:8080')
   .get('/')
   .end((err, res) => {
     expect(res).to.have.status(123);    // <= Test completes before this runs
@@ -221,7 +247,9 @@ If `Promise` is available, `request()` becomes a Promise capable library -
 and chaining of `then`s becomes possible:
 
 ```js
-chai.request.execute(app)
+import {request} from 'chai-http';
+
+request.execute(app)
   .put('/user/me')
   .send({ password: '123', confirmPassword: '123' })
   .then((res) => {
@@ -238,8 +266,10 @@ Sometimes you need to keep cookies from one request, and send them with the
 next (for example, when you want to login with the first request, then access an authenticated-only resource later). For this, `.request.agent()` is available:
 
 ```js
+import {request} from 'chai-http';
+
 // Log in
-const agent = chai.request.agent(app)
+const agent = request.agent(app)
 agent
   .post('/session')
   .send({ username: 'me', password: '123' })
@@ -254,7 +284,7 @@ agent
   });
 ```
 
-Note: The server started by `chai.request.agent(app)` will not automatically close following the test(s). You should call `agent.close()` after your tests to ensure your program exits.
+Note: The server started by `request.agent(app)` will not automatically close following the test(s). You should call `agent.close()` after your tests to ensure your program exits.
 
 ## Assertions
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,7 +5,7 @@
 //                 Austin Cawley-Edwards <https://github.com/austince>
 // TypeScript Version: 3.0
 /// <reference types="chai" />
-import * as request from 'superagent';
+import * as superAgentRequest from 'superagent';
 
 // Merge namespace with global chai
 declare global {
@@ -48,8 +48,8 @@ declare global {
   }
 
   namespace ChaiHttp {
-    interface Response extends request.Response {}
-    interface Agent extends request.SuperAgentStatic {
+    interface Response extends superAgentRequest.Response {}
+    interface Agent extends superAgentRequest.SuperAgentStatic {
       keepOpen(): Agent;
       close(callback?: (err: any) => void): Agent;
     }
@@ -59,3 +59,7 @@ declare global {
 declare function chaiHttp(chai: any, utils: any): void;
 
 export default chaiHttp;
+
+declare const request: Chai.ChaiHttpRequest;
+
+export {request};


### PR DESCRIPTION
Updates the types to export a `request` object, and also updates the readme to prefer `request.*` rather than `chai.request.*`.

