### PR TITLE
fix: add superagent types as prod dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
+        "@types/superagent": "^8.1.7",
         "charset": "^1.0.1",
         "cookiejar": "^2.1.4",
         "is-ip": "^5.0.1",
@@ -19,7 +20,6 @@
       "devDependencies": {
         "@eslint/js": "^9.3.0",
         "@types/chai": "^4.3.16",
-        "@types/superagent": "^8.1.7",
         "chai": "^5.1.0",
         "coveralls": "^3.1.1",
         "eslint": "^9.3.0",
@@ -778,20 +778,17 @@
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
-      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
-      "dev": true
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q=="
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
-      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
-      "dev": true
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ=="
     },
     "node_modules/@types/node": {
       "version": "20.12.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.8.tgz",
       "integrity": "sha512-NU0rJLJnshZWdE/097cdCBbyW1h4hEg0xpovcoAQYHl8dnEyp/NAOiE45pvc+Bd1Dt+2r94v2eGFpQJ4R7g+2w==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -800,7 +797,6 @@
       "version": "8.1.7",
       "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.7.tgz",
       "integrity": "sha512-NmIsd0Yj4DDhftfWvvAku482PZum4DBW7U51OvS8gvOkDDY0WT1jsVyDV3hK+vplrsYw8oDwi9QxOM7U68iwww==",
-      "dev": true,
       "dependencies": {
         "@types/cookiejar": "^2.1.5",
         "@types/methods": "^1.1.4",
@@ -4432,8 +4428,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/union": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -57,12 +57,12 @@
     "is-ip": "^5.0.1",
     "methods": "^1.1.2",
     "qs": "^6.12.1",
+    "@types/superagent": "^8.1.7",
     "superagent": "^9"
   },
   "devDependencies": {
     "@eslint/js": "^9.3.0",
     "@types/chai": "^4.3.16",
-    "@types/superagent": "^8.1.7",
     "chai": "^5.1.0",
     "coveralls": "^3.1.1",
     "eslint": "^9.3.0",


### PR DESCRIPTION
We expose superagent's types in our own types, so this should be a production dependency. Otherwise, we will cause errors in the typescript builds of consumers (unless they skip lib check).

It does mean we add an unnecessary dependency for non-ts people, but there's not any simple way around that.

Fixes #346