### PR TITLE
fix: use default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "main": "./index.js",
   "exports": {
     ".": {
-      "import": "./index.js",
+      "default": "./index.js",
       "types": "./types/index.d.ts"
     }
   },


### PR DESCRIPTION
We mistakenly left `import` in our export map, which means CJS consumers can't `require` chai-http right now.

This should fix it.