### PR TITLE
Drop `NODE_AUTH_TOKEN` from publish script

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -36,9 +36,5 @@ jobs:
           TAG_NAME: ${{ github.ref_name }}
       - run: npm publish --provenance --access public --tag next
         if: "github.event.release.prerelease"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_secret }}
       - run: npm publish --provenance --access public
         if: "!github.event.release.prerelease"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_secret }}


### PR DESCRIPTION
This now uses OIDC to publish