### PR TITLE
fix: use HTTPS repository URL instead of SSH

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "types": "./types/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git@github.com:chaijs/chai-http.git"
+    "url": "https://github.com/chaijs/chai-http.git"
   },
   "scripts": {
     "build": "npm run build:ts",


### PR DESCRIPTION
## Summary

The `repository.url` field in `package.json` uses `git@github.com:chaijs/chai-http.git` which is an SSH-only URL requiring SSH key configuration.

For a public npm package, HTTPS (`https://github.com/chaijs/chai-http.git`) is universally accessible to all users.

## Change
- `git@github.com:chaijs/chai-http.git` → `https://github.com/chaijs/chai-http.git`

No runtime code, dependency, or test changes.